### PR TITLE
Add integration login tests and devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.11-bookworm
+
+# Ensure pip is up to date and install the runtime dependencies needed by the
+# integration tests.
+RUN pip install --upgrade pip && \
+    pip install httpx botocore pytest pytest-asyncio

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "petsafe-integration-tests",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "postCreateCommand": "pip install -e ."
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: tests that use the live PetSafe service and stored credentials.
+asyncio_mode = auto

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,102 @@
+"""Pytest fixtures for PetSafe integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import httpx
+import pytest
+
+from petsafe.client import InvalidCodeException, PetSafeClient
+
+from .secret_store import SecretStore
+
+
+@pytest.fixture(scope="session")
+def secret_store() -> SecretStore:
+    """Shared secret store for all integration tests."""
+
+    return SecretStore()
+
+
+async def _tokens_valid(client: PetSafeClient) -> bool:
+    """Check whether the currently stored tokens allow API access."""
+
+    if not client.id_token or not client.refresh_token or not client.access_token:
+        return False
+
+    try:
+        await client.api_get("smart-feed/feeders")
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network interaction
+        if exc.response.status_code in {401, 403}:
+            return False
+        raise
+    return True
+
+
+async def _authenticate_with_code(
+    client: PetSafeClient, store: SecretStore, *, force_new_code: bool = False
+) -> None:
+    await client.request_code()
+    if force_new_code:
+        # Delete a stale code so that we prompt the user again.
+        store.data.pop("code", None)
+    code = store.prompt(
+        "code",
+        prompt=f"Enter the PetSafe verification code sent to {client._email}: ",
+        secret=True,
+    )
+    try:
+        await client.request_tokens_from_code(code)
+    except InvalidCodeException:
+        # If the stored code is stale prompt the user again.
+        store.data.pop("code", None)
+        store.save()
+        raise
+    store.update(
+        {
+            "id_token": client.id_token,
+            "refresh_token": client.refresh_token,
+            "access_token": client.access_token,
+        }
+    )
+
+
+@pytest.fixture(scope="session")
+async def petsafe_client(secret_store: SecretStore) -> AsyncIterator[PetSafeClient]:
+    """Ensure an authenticated PetSafe client for the integration tests."""
+
+    email = secret_store.prompt("email", "Enter the PetSafe account email: ")
+    client = PetSafeClient(
+        email=email,
+        id_token=secret_store.get("id_token"),
+        refresh_token=secret_store.get("refresh_token"),
+        access_token=secret_store.get("access_token"),
+    )
+
+    if not await _tokens_valid(client):
+        for attempt in range(2):
+            try:
+                await _authenticate_with_code(client, secret_store, force_new_code=attempt > 0)
+                break
+            except InvalidCodeException:
+                if attempt == 1:
+                    raise
+                print("The provided verification code was invalid. Please try again.")
+        else:  # pragma: no cover - defensive programming
+            raise AssertionError("Failed to authenticate with PetSafe API")
+
+    yield client
+
+    await client._client.aclose()
+
+
+@pytest.fixture(scope="session")
+def event_loop() -> AsyncIterator[asyncio.AbstractEventLoop]:
+    """Create an event loop for the session-scoped async fixtures/tests."""
+
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    loop.close()

--- a/tests/integration/secret_store.py
+++ b/tests/integration/secret_store.py
@@ -1,0 +1,82 @@
+"""Helpers for persisting integration test secrets locally."""
+
+from __future__ import annotations
+
+import getpass
+import json
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+_DEFAULT_SECRET_PATH = Path.home() / ".petsafe" / "integration_secrets.json"
+
+
+@dataclass
+class SecretStore:
+    """Persist PetSafe integration secrets between test runs.
+
+    The store keeps the PetSafe email address, the most recent verification code,
+    and the current set of OAuth tokens. Secrets are written to a file that is
+    only readable by the current user so that they are not checked in to the
+    repository.
+    """
+
+    path: Path = _DEFAULT_SECRET_PATH
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as handle:
+                try:
+                    self.data.update(json.load(handle))
+                except json.JSONDecodeError:
+                    # If the file is corrupted we fall back to an empty store.
+                    self.data = {}
+        self._ensure_permissions()
+
+    def _ensure_permissions(self) -> None:
+        """Ensure the secret file is only readable/writable by the user."""
+
+        if not self.path.exists():
+            return
+        try:
+            os.chmod(self.path, stat.S_IRUSR | stat.S_IWUSR)
+        except PermissionError:
+            # On platforms where chmod is not available (e.g. Windows) we ignore
+            # the error and rely on the default permissions.
+            pass
+
+    def save(self) -> None:
+        with self.path.open("w", encoding="utf-8") as handle:
+            json.dump(self.data, handle, indent=2, sort_keys=True)
+        self._ensure_permissions()
+
+    def get(self, key: str, default: Any | None = None) -> Any | None:
+        return self.data.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self.data[key] = value
+        self.save()
+
+    def prompt(self, key: str, prompt: str, *, secret: bool = False) -> str:
+        """Prompt the user for a secret value and persist it."""
+
+        existing = self.data.get(key)
+        if existing:
+            return existing
+        if secret:
+            value = getpass.getpass(prompt)
+        else:
+            value = input(prompt)
+        value = value.strip()
+        if not value:
+            raise ValueError(f"A value for '{key}' is required")
+        self.set(key, value)
+        return value
+
+    def update(self, values: Dict[str, Any]) -> None:
+        self.data.update(values)
+        self.save()

--- a/tests/integration/test_login_flow.py
+++ b/tests/integration/test_login_flow.py
@@ -1,0 +1,27 @@
+"""Integration tests that exercise the PetSafe login flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from petsafe import general
+from petsafe.client import PetSafeClient
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_tokens_available(petsafe_client: PetSafeClient) -> None:
+    """Ensure that the login flow produced usable tokens."""
+
+    assert petsafe_client.id_token, "An id token was not retrieved."
+    assert petsafe_client.refresh_token, "A refresh token was not retrieved."
+    assert petsafe_client.access_token, "An access token was not retrieved."
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_can_list_shared_products(petsafe_client: PetSafeClient) -> None:
+    """The authenticated client should be able to access a basic API endpoint."""
+
+    sharing = await general.list_product_sharing(petsafe_client)
+    assert isinstance(sharing, list)


### PR DESCRIPTION
## Summary
- add a VS Code devcontainer that provisions a Python environment and installs the project from source
- introduce a reusable secret store and pytest fixtures to capture and persist PetSafe login details for integration testing
- create an integration test suite that exercises the login flow and verifies access to a basic API endpoint while configuring pytest for asyncio tests

## Testing
- not run (live PetSafe credentials required)

------
https://chatgpt.com/codex/tasks/task_e_68dd9fc13504832699bfd3f2a4fe2b54