### PR TITLE
Fix integration login fixture client cleanup

### DIFF
--- a/tests/integration/test_login.py
+++ b/tests/integration/test_login.py
@@ -17,6 +17,7 @@ from getpass import getpass
 from pathlib import Path
 from typing import Any, Dict
 
+import httpx
 import pytest
 import pytest_asyncio
 
@@ -123,21 +124,22 @@ async def authenticated_client() -> PetSafeClient:
     secrets: Dict[str, Any] = _load_secrets()
     email = _ensure_email(secrets)
 
-    client = PetSafeClient(
-        email=email,
-        id_token=secrets.get("tokens", {}).get("id_token"),
-        refresh_token=secrets.get("tokens", {}).get("refresh_token"),
-        access_token=secrets.get("tokens", {}).get("access_token"),
-    )
+    async with httpx.AsyncClient() as httpx_client:
+        client = PetSafeClient(
+            email=email,
+            id_token=secrets.get("tokens", {}).get("id_token"),
+            refresh_token=secrets.get("tokens", {}).get("refresh_token"),
+            access_token=secrets.get("tokens", {}).get("access_token"),
+            client=httpx_client,
+        )
 
-    await _ensure_active_tokens(client, secrets)
+        await _ensure_active_tokens(client, secrets)
 
-    try:
-        yield client
-    finally:
-        secrets["tokens"] = _collect_tokens(client)
-        _save_secrets(secrets)
-        await client._client.aclose()  # noqa: SLF001 - intentional use of private attribute
+        try:
+            yield client
+        finally:
+            secrets["tokens"] = _collect_tokens(client)
+            _save_secrets(secrets)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_login.py
+++ b/tests/integration/test_login.py
@@ -116,7 +116,7 @@ async def _ensure_active_tokens(client: PetSafeClient, secrets: Dict[str, Any]) 
     _save_secrets(secrets)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def authenticated_client() -> PetSafeClient:
     if not sys.stdin.isatty():
         pytest.skip("Interactive login tests require a TTY.")


### PR DESCRIPTION
## Summary
- manage the PetSafe AsyncClient with an async context manager in the login integration fixture
- ensure the cached tokens are still persisted without closing the event loop prematurely

## Testing
- not run (interactive login test requires user input)


------
https://chatgpt.com/codex/tasks/task_e_68de9277c0688326ac5c1f040d59df23