### PR TITLE
Populate SmartDoor preferences when fetching devices

### DIFF
--- a/petsafe/client.py
+++ b/petsafe/client.py
@@ -83,7 +83,25 @@ class PetSafeClient:
         content = response.content.decode("UTF-8")
         data = json.loads(content)
         devices = data.get("data", data)
-        return [DeviceSmartDoor(self, door_data) for door_data in devices]
+        doors = [DeviceSmartDoor(self, door_data) for door_data in devices]
+        if not doors:
+            return []
+
+        preferences = await asyncio.gather(
+            *(door.get_preferences() for door in doors)
+        )
+
+        for door, prefs in zip(doors, preferences):
+            if isinstance(prefs, dict):
+                friendly_name = prefs.get("friendlyName")
+                if friendly_name is not None:
+                    door.data["friendlyName"] = friendly_name
+
+                timezone = prefs.get("tz")
+                if timezone is not None:
+                    door.data["tz"] = timezone
+
+        return doors
 
     async def request_code(self) -> None:
         """

--- a/petsafe/devices.py
+++ b/petsafe/devices.py
@@ -793,6 +793,18 @@ class DeviceSmartDoor:
         return self.data.get("schedules", [])
 
     @property
+    def friendly_name(self) -> Optional[str]:
+        """Return the SmartDoor friendly name preference."""
+
+        return self.data.get("friendlyName")
+
+    @property
+    def timezone(self) -> Optional[str]:
+        """Return the SmartDoor timezone preference."""
+
+        return self.data.get("tz")
+
+    @property
     def mode(self) -> Optional[str]:
         """Return the currently reported operating mode."""
 


### PR DESCRIPTION
## Summary
- fetch SmartDoor preferences immediately after retrieving each SmartDoor
- apply the friendly name and timezone preferences to the SmartDoor payload
- expose convenience properties for friendly name and timezone access

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ffe44fd61c832697bf678a3e0c870e