### PR TITLE
Fix smartdoor integration test

### DIFF
--- a/tests/integration/test_smartdoor_api.py
+++ b/tests/integration/test_smartdoor_api.py
@@ -75,7 +75,7 @@ async def test_get_single_smartdoor(authenticated_client: PetSafeClient) -> None
     payload = response.json()
     print(_dump_response(payload))
 
-    fresh = await authenticated_client.get_smartdoor(door.api_name)
+    fresh = await DeviceSmartDoor.get_smartdoor(authenticated_client, door.api_name)
     assert isinstance(fresh, DeviceSmartDoor)
     assert fresh.api_name == door.api_name
 


### PR DESCRIPTION
## Summary
- update the SmartDoor integration test to call the DeviceSmartDoor helper for fetching a single door

## Testing
- not run (requires live PetSafe credentials)


------
https://chatgpt.com/codex/tasks/task_e_690bc3edd1a08326b6ee120bb3102ed1