### PR TITLE
Add integration test for smartdoor preferences

### DIFF
--- a/tests/integration/test_smartdoor_api.py
+++ b/tests/integration/test_smartdoor_api.py
@@ -91,14 +91,9 @@ async def test_smartdoor_preferences_populated(
     smartdoors = await authenticated_client.get_smartdoors()
     door = _ensure_smartdoor_available(smartdoors)
 
-    print(
-        "SmartDoor attributes:",
-        {
-            "api_name": door.api_name,
-            "friendly_name": door.friendly_name,
-            "timezone": door.timezone,
-        },
-    )
+    print("SmartDoor api_name:", door.api_name)
+    print("SmartDoor friendly_name:", door.friendly_name)
+    print("SmartDoor timezone:", door.timezone)
     assert door.friendly_name, "Expected SmartDoor friendly name populated from API"
     assert door.timezone, "Expected SmartDoor timezone populated from API"
 

--- a/tests/integration/test_smartdoor_api.py
+++ b/tests/integration/test_smartdoor_api.py
@@ -91,11 +91,20 @@ async def test_smartdoor_preferences_populated(
     smartdoors = await authenticated_client.get_smartdoors()
     door = _ensure_smartdoor_available(smartdoors)
 
+    print(
+        "SmartDoor attributes:",
+        {
+            "api_name": door.api_name,
+            "friendly_name": door.friendly_name,
+            "timezone": door.timezone,
+        },
+    )
     assert door.friendly_name, "Expected SmartDoor friendly name populated from API"
     assert door.timezone, "Expected SmartDoor timezone populated from API"
 
     preferences = await door.get_preferences()
 
+    print("SmartDoor preferences:", preferences)
     assert preferences.get("friendlyName") == door.friendly_name
     assert preferences.get("tz") == door.timezone
 

--- a/tests/integration/test_smartdoor_api.py
+++ b/tests/integration/test_smartdoor_api.py
@@ -85,6 +85,22 @@ async def test_get_single_smartdoor(authenticated_client: PetSafeClient) -> None
 
 
 @pytest.mark.asyncio
+async def test_smartdoor_preferences_populated(
+    authenticated_client: PetSafeClient,
+) -> None:
+    smartdoors = await authenticated_client.get_smartdoors()
+    door = _ensure_smartdoor_available(smartdoors)
+
+    assert door.friendly_name, "Expected SmartDoor friendly name populated from API"
+    assert door.timezone, "Expected SmartDoor timezone populated from API"
+
+    preferences = await door.get_preferences()
+
+    assert preferences.get("friendlyName") == door.friendly_name
+    assert preferences.get("tz") == door.timezone
+
+
+@pytest.mark.asyncio
 async def test_smartdoor_activity(authenticated_client: PetSafeClient) -> None:
     smartdoors = await authenticated_client.get_smartdoors()
     door = _ensure_smartdoor_available(smartdoors)


### PR DESCRIPTION
## Summary
- add an integration test to ensure SmartDoor devices expose their friendly name and timezone
- verify the preference endpoint agrees with the data populated on the device objects

## Testing
- pytest tests/integration/test_smartdoor_api.py -k preferences -vv

------
https://chatgpt.com/codex/tasks/task_e_690be5dadf0083269496fab04941dbe0