### PR TITLE
Rename project to petsafe-api, update README and bump package version to 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
-# PetSafe Smart Feed - Python API
-Connect and control a PetSafe Smart Feed device using the PetSafe-SmartFeed API.
+# petsafe-api
+Connect and control PetSafe Smart Feed, ScoopFree, and Smart Door devices using the PetSafe API.
 
 > **BREAKING CHANGE:** Version 2.0 uses the new PetSafe API.
 > You will need to request new tokens.
 
 > PetSafe will lock your account if you request data more often than once per 5 minutes.
+
+## Project rename
+This repository is now named **petsafe-api** and the published package name is **petsafe-api** on PyPI.
+
+> Import paths are unchanged: continue using `import petsafe` and `python -m petsafe`.
+
+## Acknowledgements
+This project builds on the excellent prior work from the original developers:
+- https://github.com/Techzune/petsafe_smartfeed
+- https://github.com/dcmeglio/petsafe
+
+Thank you to both projects for building the API integrations for existing feeder and ScoopFree functionality. This repository includes all of that previous work, with Smart Door API support added on top.
 
 ## Installation
 `pip install petsafe-api`

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="petsafe-api",
-    version="1.0.1",
+    version="3.0.1",
     author="Jordan Stremming & Dominick Meglio & Thomas Wright",
     license="MIT",
     author_email="thomas.h.f.wright@gmail.com",
     description="Provides ability to connect and control a PetSafe Smart Feed, Scoopfree, and Smart Door devices using the PetSafe API.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/ThomasHFWright/petsafe",
+    url="https://github.com/ThomasHFWright/petsafe-api",
     packages=setuptools.find_packages(),
     install_requires=["httpx", "botocore"],
     classifiers=[


### PR DESCRIPTION
### Motivation
- Rename and rebrand the repository/package to support a wider set of PetSafe devices (Smart Feed, ScoopFree, and Smart Door) and to publish on PyPI as `petsafe-api`. 
- Move to the new PetSafe API (breaking change) which requires new tokens and enforces rate limits. 
- Provide attribution for upstream projects and clarify install/login instructions and import stability.

### Description
- Replace README header and content to reflect the new project name, add a `Project rename` section, and add `Acknowledgements` for upstream work. 
- Keep user-facing usage unchanged by noting that import paths remain `import petsafe` and `python -m petsafe`. 
- Update packaging metadata in `setup.py` to set `name="petsafe-api"`, bump `version` to `3.0.1`, and update `url` to `https://github.com/ThomasHFWright/petsafe-api` while preserving the package description and requirements. 
- Preserve the token acquisition instructions and highlight the breaking `PetSafe API` change and rate-limit behavior.

### Testing
- No automated tests were included or executed for this documentation and packaging metadata change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d1335170832685ac1d760ebe9696)