### PR TITLE
Update GitHub Actions workflow to modern PyPI publish action and steps

### DIFF
--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -1,6 +1,4 @@
-# This workflow deploys a new release on PyPI once a pull request is closed
-
-name: Deploy to PyPI
+name: Publish to PyPI
 
 on:
   push:
@@ -8,16 +6,25 @@ on:
       - 'v*'
 
 jobs:
-  pypi-deploy:
-    name: Build and publish Python 🐍 distributions 📦 to live PyPI
+  pypi-publish:
+    name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Checkout repository
-      uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
-    - name: Publish distribution 📦 to PyPI
-      uses: JRubics/poetry-publish
-      with:
-        ignore_dev_requirements: 'yes'
-        pypi_token: ${{ secrets.PYPI_PASSWORD }}
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Motivation
- Modernize and simplify the PyPI publishing workflow by switching to the official pypa publish action and newer GitHub Action versions.
- Ensure the workflow uses current action releases and explicit Python setup for reproducible builds.
- Configure minimal runtime permissions for the job to align with GitHub Actions best practices.

### Description
- Renamed the workflow display name to `Publish to PyPI` and the job to `pypi-publish` while keeping the tag trigger for `v*` pushes.
- Replaced `actions/checkout@master` with `actions/checkout@v4` and added an explicit `actions/setup-python@v5` step with `python-version: '3.x'`.
- Added `permissions` (`contents: read` and `id-token: write`) to the job and added a `Build package` step that runs `python -m pip install --upgrade pip build` and `python -m build`.
- Replaced the third-party `JRubics/poetry-publish` action with the official `pypa/gh-action-pypi-publish@release/v1` for publishing distributions.

### Testing
- No automated tests were executed as part of this change to the CI workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d5884ad483269a03c231d2e02c34)