### PR TITLE
Fix async CLI auth calls in module entrypoint

### DIFF
--- a/petsafe/__main__.py
+++ b/petsafe/__main__.py
@@ -1,5 +1,6 @@
 import sys
 import argparse
+import asyncio
 
 from petsafe import PetSafeClient
 
@@ -17,20 +18,24 @@ if len(sys.argv) < 2:
 # parse for arguments
 args = parser.parse_args()
 
-client = PetSafeClient(email=args.email)
-client.request_code()
-print("Code requested, please check your email.")
-print("")
+async def main() -> None:
+    client = PetSafeClient(email=args.email)
+    await client.request_code()
+    print("Code requested, please check your email.")
+    print("")
 
-code = input("Enter email code: ")
-client.request_tokens_from_code(code)
+    code = input("Enter email code: ")
+    await client.request_tokens_from_code(code)
 
-print("")
-print("IdToken:")
-print(client.id_token)
-print("")
-print("AccessToken:")
-print(client.access_token)
-print("")
-print("RefreshToken:")
-print(client.refresh_token)
+    print("")
+    print("IdToken:")
+    print(client.id_token)
+    print("")
+    print("AccessToken:")
+    print(client.access_token)
+    print("")
+    print("RefreshToken:")
+    print(client.refresh_token)
+
+
+asyncio.run(main())

--- a/petsafe/__main__.py
+++ b/petsafe/__main__.py
@@ -24,7 +24,12 @@ async def main() -> None:
     print("Code requested, please check your email.")
     print("")
 
-    code = input("Enter email code: ")
+    try:
+        code = input("Enter email code: ")
+    except EOFError:
+        print("\nNo code entered (EOF). Exiting.")
+        return
+
     await client.request_tokens_from_code(code)
 
     print("")


### PR DESCRIPTION
### Motivation
- The CLI previously called async authentication methods without awaiting them, causing `RuntimeWarning: coroutine ... was never awaited` when running `python -m petsafe`.
- The entrypoint needs to perform the auth flow synchronously from the process perspective while using the existing async client methods.

### Description
- Import `asyncio` and wrap the CLI flow in an async `main()` function to run the async auth sequence.
- Await `PetSafeClient.request_code()` before prompting the user for the verification code and await `PetSafeClient.request_tokens_from_code(code)` before printing tokens.
- Execute the async flow with `asyncio.run(main())` so the module entrypoint runs correctly in a synchronous process.

### Testing
- Ran `python -m pytest -q tests/test_smartdoor_modes.py` which completed successfully (`6 passed`).
- Ran `python -m compileall petsafe/__main__.py` which completed successfully (compiled without error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7db5a456c832698657521099f422e)