### PR TITLE
Bump package version to 3.0.3 and require version bumps on PRs to master

### DIFF
--- a/.github/workflows/require-version-bump.yml
+++ b/.github/workflows/require-version-bump.yml
@@ -1,0 +1,65 @@
+name: Require version bump
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure version changed
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+
+          if ! git show "origin/${BASE_BRANCH}:setup.py" > /tmp/base_setup.py 2>/dev/null; then
+            echo "::error::Could not read setup.py from base branch origin/${BASE_BRANCH}."
+            exit 1
+          fi
+
+          if [[ ! -f setup.py ]]; then
+            echo "::error::setup.py not found in PR branch."
+            exit 1
+          fi
+
+          BASE_VERSION=$(python - <<'PY'
+import re
+from pathlib import Path
+text = Path('/tmp/base_setup.py').read_text()
+m = re.search(r'version="([0-9]+\.[0-9]+\.[0-9]+)"', text)
+if not m:
+    raise SystemExit(1)
+print(m.group(1))
+PY
+)
+
+          HEAD_VERSION=$(python - <<'PY'
+import re
+from pathlib import Path
+text = Path('setup.py').read_text()
+m = re.search(r'version="([0-9]+\.[0-9]+\.[0-9]+)"', text)
+if not m:
+    raise SystemExit(1)
+print(m.group(1))
+PY
+)
+
+          echo "Base version: ${BASE_VERSION}"
+          echo "PR version:   ${HEAD_VERSION}"
+
+          if [[ "${BASE_VERSION}" == "${HEAD_VERSION}" ]]; then
+            echo "::error::Version was not bumped. Update setup.py version for PRs into master."
+            exit 1
+          fi
+
+          echo "Version bump detected."

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="petsafe-api",
-    version="3.0.1",
+    version="3.0.3",
     author="Jordan Stremming & Dominick Meglio & Thomas Wright",
     license="MIT",
     author_email="thomas.h.f.wright@gmail.com",


### PR DESCRIPTION
### Motivation
- Ensure the package version is updated for the next release by bumping the package metadata.
- Prevent accidental merges into `master` without a version bump by enforcing a CI check on PRs.

### Description
- Bumped the package version in `setup.py` from `3.0.1` to `3.0.3`.
- Added `.github/workflows/require-version-bump.yml` which runs on `pull_request` to `master` and uses `actions/checkout@v4` with `fetch-depth: 0` to compare `setup.py` in the PR against the base branch.
- The workflow extracts the `version="x.y.z"` value from both base and head `setup.py` using a regex and fails the job with an error when the versions are identical.

### Testing
- Ran `pytest -q` which completed successfully with `6 passed, 10 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7dd8c0a888326a0f724ee214c7b5d)