### PR TITLE
Require semver (major/minor/patch) label on PRs to master

### DIFF
--- a/.github/workflows/require-semver-label.yml
+++ b/.github/workflows/require-semver-label.yml
@@ -1,0 +1,35 @@
+name: Require Semver Label
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - edited
+
+jobs:
+  validate-label:
+    name: Validate major/minor/patch label
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const requiredLabels = ['major', 'minor', 'patch'];
+            const labels = context.payload.pull_request.labels.map((label) => label.name.toLowerCase());
+            const matched = requiredLabels.filter((label) => labels.includes(label));
+
+            if (matched.length !== 1) {
+              core.setFailed(
+                `PRs targeting master must include exactly one of these labels: ${requiredLabels.join(', ')}. Found: ${matched.length ? matched.join(', ') : 'none'}`
+              );
+            } else {
+              core.info(`Found required semver label: ${matched[0]}`);
+            }


### PR DESCRIPTION
### Motivation
- Ensure every PR merged into `master` is explicitly marked with a semantic-version intent so releases and changelogs can be automated and unambiguous.

### Description
- Add a GitHub Actions workflow at `/.github/workflows/require-semver-label.yml` that triggers on `pull_request` events targeting `master` and fails unless the PR has exactly one of the labels `major`, `minor`, or `patch` by using `actions/github-script@v7` to validate labels.

### Testing
- Reviewed the workflow YAML via `sed -n '1,200p' .github/workflows/require-semver-label.yml` and `nl -ba .github/workflows/require-semver-label.yml`, and both checks completed successfully; no runtime CI tests were executed locally because the workflow runs in GitHub Actions on PR events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e814443483268686a60754f7a8cc)