### PR TITLE
fix: get_last_feeding returns most recent FEED_DONE regardless of API order

### DIFF
--- a/petsafe/devices.py
+++ b/petsafe/devices.py
@@ -83,10 +83,13 @@ class DeviceSmartFeed:
 
         """
         messages = await self.get_messages_since()
-        for message in messages:
-            if message["message_type"] == "FEED_DONE":
-                return message
-        return None
+        feed_done = [
+            message for message in messages
+            if message.get("message_type") == "FEED_DONE"
+            and isinstance(message.get("payload"), dict)
+            and isinstance(message["payload"].get("time"), int)
+        ]
+        return max(feed_done, key=lambda message: message["payload"]["time"], default=None)
 
     async def feed(
         self, amount: int = 1, slow_feed: bool = None, update_data: bool = True


### PR DESCRIPTION
## Problem

`get_last_feeding()` stopped returning the correct feeding after the PetSafe API changed the ordering of messages returned by `GET /smart-feed/feeders/{id}/messages?days=N`.

Previously the API returned messages **newest-first**, so iterating and returning the first `FEED_DONE` match was correct. In the last week or so, it seems API silently changed to returning messages **oldest-first**, causing `get_last_feeding()` to return a stale feeding from days ago instead of the most recent one.

### Example API response (current ordering — oldest first)

```json
[
  {"message_type": "FEED_DONE", "created_at": "2025-04-20T08:00:00Z", "payload": {"time": 1745136000, "amount": 1}},
  {"message_type": "FEED_DONE", "created_at": "2025-04-20T12:00:00Z", "payload": {"time": 1745150400, "amount": 1}},
  {"message_type": "FEED_DONE", "created_at": "2025-04-20T17:00:00Z", "payload": {"time": 1745168400, "amount": 2}}
]
```

With the old implementation the first `FEED_DONE` found (8:00 AM) was returned instead of the most recent one (5:00 PM).

## Fix

Instead of returning the first `FEED_DONE` in iteration order, filter to all valid `FEED_DONE` entries and return the one with the highest `payload.time` Unix timestamp — making the result correct regardless of what order the API returns messages in the future.