### PR TITLE
fix: fix last feeding date

### DIFF
--- a/petsafe/devices.py
+++ b/petsafe/devices.py
@@ -83,10 +83,15 @@ class DeviceSmartFeed:
 
         """
         messages = await self.get_messages_since()
-        for message in messages:
-            if message["message_type"] == "FEED_DONE":
-                return message
-        return None
+        feedings = [
+            message
+            for message in messages
+            if isinstance(message, dict)
+            and message.get("message_type") == "FEED_DONE"
+            and isinstance(message.get("payload"), dict)
+            and isinstance(message["payload"].get("time"), (int, float))
+        ]
+        return max(feedings, key=lambda message: message["payload"]["time"], default=None)
 
     async def feed(
         self, amount: int = 1, slow_feed: bool = None, update_data: bool = True

--- a/tests/test_feeder_messages.py
+++ b/tests/test_feeder_messages.py
@@ -1,0 +1,74 @@
+"""Unit tests for SmartFeed message handling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from petsafe.devices import DeviceSmartFeed
+import pytest
+
+
+def _create_feeder() -> DeviceSmartFeed:
+    """Create a feeder without making API requests."""
+    return DeviceSmartFeed(AsyncMock(), {"thing_name": "feeder-1"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [
+            {"message_type": "FEED_DONE", "payload": {"time": 100}},
+            {"message_type": "FEED_DONE", "payload": {"time": 300}},
+            {"message_type": "FEED_DONE", "payload": {"time": 200}},
+        ],
+        [
+            {"message_type": "FEED_DONE", "payload": {"time": 300}},
+            {"message_type": "FEED_DONE", "payload": {"time": 200}},
+            {"message_type": "FEED_DONE", "payload": {"time": 100}},
+        ],
+    ],
+)
+async def test_get_last_feeding_selects_latest_timestamp(messages) -> None:
+    """The latest feeding should not depend on API response ordering."""
+    feeder = _create_feeder()
+    feeder.get_messages_since = AsyncMock(return_value=messages)
+
+    result = await feeder.get_last_feeding()
+
+    assert result == {"message_type": "FEED_DONE", "payload": {"time": 300}}
+
+
+@pytest.mark.asyncio
+async def test_get_last_feeding_ignores_other_and_malformed_messages() -> None:
+    """Non-feeding and malformed messages should not prevent selecting a feeding."""
+    latest = {"message_type": "FEED_DONE", "payload": {"time": 300}}
+    feeder = _create_feeder()
+    feeder.get_messages_since = AsyncMock(
+        return_value=[
+            None,
+            {},
+            {"message_type": "FEED_DONE"},
+            {"message_type": "FEED_DONE", "payload": None},
+            {"message_type": "FEED_DONE", "payload": {"time": "newest"}},
+            {"message_type": "STATUS", "payload": {"time": 400}},
+            {"message_type": "FEED_DONE", "payload": {"time": 100}},
+            latest,
+        ]
+    )
+
+    assert await feeder.get_last_feeding() is latest
+
+
+@pytest.mark.asyncio
+async def test_get_last_feeding_returns_none_without_valid_feeding() -> None:
+    """No valid feeding messages should produce no result."""
+    feeder = _create_feeder()
+    feeder.get_messages_since = AsyncMock(
+        return_value=[
+            {"message_type": "STATUS", "payload": {"time": 300}},
+            {"message_type": "FEED_DONE", "payload": {}},
+        ]
+    )
+
+    assert await feeder.get_last_feeding() is None


### PR DESCRIPTION
## Summary

Fixes `DeviceSmartFeed.get_last_feeding()` returning an older feeding event when the PetSafe API returns messages in chronological order.

Previously, the method returned the first `FEED_DONE` message and assumed messages were ordered newest-first. The API can return oldest-first, causing Home Assistant’s Last Feeding sensor to remain stuck on an earlier event even though newer scheduled and manual feedings appeared in the PetSafe app.

## Changes

- Select the `FEED_DONE` message with the greatest `payload.time`.
- Avoid relying on API response ordering.
- Ignore unrelated or malformed messages safely.
- Return `None` when no valid feeding event exists.
- Add tests covering:
  - Oldest-first responses
  - Newest-first responses
  - Mixed message types
  - Malformed messages
  - No valid feeding events

## Validation

- `petsafe-api` unit tests: 10 passed.
- Home Assistant integration critical tests using the fixed local package: 90 passed.
- Tested on local Home Assistant installation